### PR TITLE
Display the effect of aligned_double4 in dynamic allocating.

### DIFF
--- a/aligned_heap_vectorization.cpp
+++ b/aligned_heap_vectorization.cpp
@@ -24,8 +24,10 @@ public:
   void operator delete (void* ptr) {
     ::operator delete(*(reinterpret_cast<void**>(ptr) - 1));
   }
-
+  
+  int x;
   aligned_double4 data;
+  int y, z;
 };
 
 Vector4d operator+ (const Vector4d& v1, const Vector4d& v2) {
@@ -46,8 +48,10 @@ int main() {
   Vector4d* input1 = new Vector4d{1, 1, 1, 1};
   Vector4d* input2 = new Vector4d{1, 2, 3, 4};
 
+  std::cout << "address of input1.x: " << &input1->x << std::endl;
   std::cout << "address of input1: " << input1->data << std::endl;
-  std::cout << "address of input2: " << input2->data << std::endl;
+  std::cout << "address of input1.y: " << &input1->y << std::endl;
+  std::cout << "address of input1.z: " << &input1->z << std::endl;
 
   Vector4d result = *input1 + *input2;
 


### PR DESCRIPTION
Please check the change in `aligned_heap_vectorization.cpp`.

We added `x` before `data` and `y` `z` after `data`. Then print the address for all these fields.

The output in my computer is:
```
address of input1.x: 0x55fb7ffa9ec0
address of input1: 0x55fb7ffa9ee0
address of input1.y: 0x55fb7ffa9f00
address of input1.z: 0x55fb7ffa9f04
(2, 3, 4, 5)
```

You can see `x` `data` and `y` are all 32-byte aligned, but `z` is not.
`x` is 32-byte aligned because it's the first field in the object and the object is 32-byte aligned.
`data` is 32-byte aligned because the `aligned_double4` still take effect, which forms the relative location for the `data` in the object.
`y` is 32-byte aligned because the `data` happens to occupy 32 bytes. So `y` just locate behind it.
`z` is not 32-byte aligned because `y` only occupies 4 bytes. `z` itself doesn't declare any alignment attributes, so it is put right behind `y`.